### PR TITLE
KG-14460: Implementing secure long-polling

### DIFF
--- a/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptSession.java
+++ b/src/main/java/org/kaazing/gateway/transport/http/HttpAcceptSession.java
@@ -47,5 +47,4 @@ public interface HttpAcceptSession extends HttpSession {
     
     CommitFuture commit();
     
-    void shutdownWrite();
 }

--- a/src/main/java/org/kaazing/gateway/transport/http/HttpSession.java
+++ b/src/main/java/org/kaazing/gateway/transport/http/HttpSession.java
@@ -85,4 +85,6 @@ public interface HttpSession extends BridgeSession {
 		
 	String getReason();
 
+	void shutdownWrite();
+
 }


### PR DESCRIPTION
* Now gateway adds Content-Length on downstream responses. This helps the client to reuse
an underlying connection for multiple HTTP request/responses. When long polling is detected,
it calls suspendWrite(), write data, shutdownWrite(), resumeWrite() on downstream HTTP connection.
This enables the data to be buffered and Content-Length to be written.

* canStream() logic is changed. Previously, if there certain headers like (Via etc), gateway
doesn't stream at all eventhough a proxy may support streaming. The new logic gives an opportunity
to stream even when proxy is in the path. If the proxy buffers, the client would establish
a connection (after certain duration) with .ki=p and that would trigger long-polling.

* X-Kaazing-Proxy-Buffering: on|off is implemented. buffer size is not implemented. This is
only hint to gateway for the first request but not required as client would send .ki=p on
subsequent requests to trigger long polling.